### PR TITLE
Unable to build JSDuck gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The `jsduck/output` directory should be available under `http://localhost/docs/`
 
   `> ln -s path/to/jsduck/output docs`
 
-9. `> rake bump["0.0.2"]` (update version number if you made any changes)
+11. `> rake bump["0.0.2"]` (update version number if you made any changes)
 1. `> rake gem`
 1. If you want to commit a new version, remove the old gem and add a new one to the repository.
 
@@ -39,9 +39,9 @@ Read the instructions in the [`ckeditor-docs`](https://github.com/ckeditor/ckedi
 ## Modifying JSDuck
 
 1. Rebuilding the gem package:
-  1. If you modified JSDuck version (merged upstream's `master`), make sure to run all `rake` tasks starting from `rake configure` in step 5 above.
+  1. If you modified JSDuck version (merged upstream's `master`), make sure to run all `rake` tasks starting from `rake configure` in step 8 above.
   1. If you only modified JSDuck code within a previously built version, it's enough to build the gem package, unless templates have been modified.
-1. Commiting changes:
+1. Committing changes:
   1. All code modifications should be done in the `ckeditor-customizations` branch, so that they would be easily reapplicable in the future.
   1. After making any changes, first commit code changes (this may be more than one commit), then bump the JSDuck version, build a new gem package, remove the old one from the repository and add the new one, then commit the rebuilt package.
 1. Testing:

--- a/README.md
+++ b/README.md
@@ -10,20 +10,25 @@ This repository is used for storing CKEditor modifications for [JSDuck](https://
 
 ## Building the CKEditor JSDuck Gem
 
-Full guide can be found in the [JSDuck wiki](https://github.com/ckeditor/jsduck/wiki/Hacking).
+More detailed guide can be found in the [JSDuck wiki](https://github.com/senchalabs/jsduck/wiki/Hacking).
 
-1. Install [Sencha SDK Tools](http://www.sencha.com/products/sdk-tools/download/) for your OS.
-1. `> sudo gem install rake rspec compass json rdiscount parallel dimensions rkelly-remix`
+The most suitable version is `ruby 1.9.3`. You may use [RVM](https://rvm.io/) for your convenience. 
+
+1. Install [Sencha SDK Tools](https://github.com/Shereef/Sencha-Touch-2) for your OS.
+1. `> sudo gem install rake rspec json rdiscount parallel dimensions rkelly-remix`
+1. `> sudo gem install sass -v 3.1.1`
+1. `> sudo gem install compass -v 0.12.2`
 1. `> git clone git@github.com:ckeditor/jsduck.git`
 1. `> cd jsduck`
 1. `> git co stable`
 1. `> rake configure`
 1. `> rake ext4` (when executed for the first time gives a lot of warnings &mdash; you can repeat it)
-1. To generate the gem you first need to have a JSDuck-built documentation application available at `http://localhost/docs/`:
+1. To generate the gem you first need to have a JSDuck-built documentation application available at `http://localhost/docs/`.
+The `jsduck/output` directory should be available under `http://localhost/docs/` so the easiest way is to run from localhost's root:
 
-  `> ln -s path/to/jsduck/output docs` (from localhost's root)
+  `> ln -s path/to/jsduck/output docs`
 
-1. `> rake bump["0.0.2"]` (update version number if you made any changes)
+9. `> rake bump["0.0.2"]` (update version number if you made any changes)
 1. `> rake gem`
 1. If you want to commit a new version, remove the old gem and add a new one to the repository.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Read the instructions in the [`ckeditor-docs`](https://github.com/ckeditor/ckedi
   1. After making any changes, first commit code changes (this may be more than one commit), then bump the JSDuck version, build a new gem package, remove the old one from the repository and add the new one, then commit the rebuilt package.
 1. Testing:
 
-  For testing purposes you can use the script available in `bin/ckeditor-jsduck` instead of constantly installing the rebuilt gem package. You need to temporarily modify the [`build.sh`](https://github.com/ckeditor/ckeditor-docs/blob/master/build.sh) script from the CKEditor documentation repository to use this file.
+  For testing purposes you can use the script available in `bin/ckeditor-jsduck` instead of constantly installing the rebuilt gem package. You need to temporarily modify the [`gruntfile.js`](https://github.com/ckeditor/ckeditor-docs/blob/master/gruntfile.js#L51) script from the CKEditor documentation repository to use this file. The `cmd` should point to full path with `bin/ckeditor-jsduck` instead of `ckeditor-jsduck`.
 
   If you modified JSDuck templates, then you need to run rake tasks up to `rake gem` (excluding bumping up the version of course), otherwise `bin/ckeditor-jsduck` will still be using old minified templates.
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,10 @@ def os_is_windows?
   RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
 end
 
+def os_is_osx?
+  RbConfig::CONFIG['host_os'] =~ /darwin|mac os/
+end
+
 require 'rspec'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
@@ -99,7 +103,7 @@ def compress
   # Clean up template-min/ left over from previous compress task
   system("rm", "-rf", "template-min")
   # Copy template/ files to template-min/
-  system("cp", "-r", "template", "template-min")
+  system("cp", os_is_osx? ? "-R" : "-r", "template", "template-min")
   # Now do everything that follows in template-min/ dir
   dir = "template-min"
 
@@ -194,10 +198,10 @@ end
 
 # Download ExtJS into template/extjs
 task :get_extjs do
-  system "curl -o template/extjs.zip http://cdn.sencha.com/ext-4.1.1a-gpl.zip"
+  system "curl -o template/extjs.zip https://ext4all.com/ext/download/ext-4.1.1-gpl.zip"
   system "unzip template/extjs.zip -d template/"
   system "rm -rf template/extjs"
-  system "mv template/ext-4.1.1a template/extjs"
+  system "mv template/extjs-4.1.1 template/extjs"
   system "rm template/extjs.zip"
 end
 

--- a/ckeditor-jsduck.gemspec
+++ b/ckeditor-jsduck.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors = ["Rene Saarsoo", "Nick Poulden"]
   s.email = "rene.saarsoo@sencha.com"
   s.rubyforge_project = s.name
-  s.license = "GPL-3"
+  s.license = "GPL-3.0"
 
   s.files = ['bin/ckeditor-jsduck', 'COPYING', 'README.md']
   s.files += Dir['lib/**/*']


### PR DESCRIPTION
There were few problems here:

* Outdated ExtJS 4 link in [`get_extjs`](https://github.com/ckeditor/jsduck/compare/ckeditor-customizations...ckeditor:t/4?expand=1#diff-52c976fc38ed2b4e3b1192f8a8e24cffR200) (not sure if we should use the unofficial one, but there is no official one AFAIK - maybe we should put it somwhere in this repo?).
* [`-R` flag](https://github.com/ckeditor/jsduck/compare/ckeditor-customizations...ckeditor:t/4?expand=1#diff-52c976fc38ed2b4e3b1192f8a8e24cffR106) should be used on OS X instead of `-r`.
* [Dependencies](https://github.com/ckeditor/jsduck/compare/ckeditor-customizations...ckeditor:t/4?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R15) .

---

Closes #4.